### PR TITLE
Improve pre-commit hook

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,10 @@
+{
+  "formatter": {
+    "indentStyle": "space"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "pre-commit": [
     "precommit"
   ],
+  "nano-staged": {
+    "*.{js,ts}": "biome check --apply"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -29,6 +32,7 @@
     "winston": "^3.8.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.2.2",
     "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
@@ -38,9 +42,9 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "concurrently": "^8.2.1",
+    "nano-staged": "^0.8.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^5.0.1",
-    "rome": "^11.0.0",
     "tsc-watch": "^6.0.0",
     "typescript": "^4.9.5"
   }

--- a/pre-commit
+++ b/pre-commit
@@ -1,11 +1,2 @@
-#!/bin/sh
-FILES=$(git diff --name-only --cached --diff-filter=d | grep -E '\.(js|ts)$')
-
-if [ -n "$FILES" ]; then
-    echo "Running formatter & linter.."
-    npx rome check $FILES --apply-suggested
-    npx rome format $FILES --write --indent-style space --indent-size 2 --quote-style single
-    git add $FILES
-else
-    echo "No files to format.."
-fi
+echo "Formatting and linting..."
+nano-staged


### PR DESCRIPTION
- Upgrade from Rome to Biome
- Configure Biome in a separate file instead of a CLI option, so that the config will be respected by the Biome VS Code plugin too
- Only format and lint changed files (nano-staged)
- `biome check --apply` will run both formatter and linter, so no need for a separate `biome format --write`
- Imports will be auto-organized by Biome

(Related: haagahelia/siba-fe#207)