### PR TITLE
be-fix-departmentplanner-to-initial-caps-in-table-name

### DIFF
--- a/src/routes/departmentplanner.ts
+++ b/src/routes/departmentplanner.ts
@@ -28,14 +28,14 @@ departmentplanner.get(
           req,
           res,
           data,
-          'getDepartmentplanners successful - Departmentplanner',
+          'getDepartmentPlanners successful - DepartmentPlanner',
         );
       })
       .catch((err) => {
         requestErrorHandler(
           req,
           res,
-          `${err} Oops! Nothing came through - Departmentplanner`,
+          `${err} Oops! Nothing came through - DepartmentPlanner`,
         );
       });
   },
@@ -58,7 +58,7 @@ departmentplanner.get(
           req,
           res,
           result,
-          'getDepartmentplanners successful - Departmentplanner',
+          'getDepartmentPlanners successful - DepartmentPlanner',
         );
       })
       .catch((error) => {
@@ -66,7 +66,7 @@ departmentplanner.get(
           req,
           res,
           error,
-          'Oops! Nothing came through - Departmentplanner',
+          'Oops! Nothing came through - DepartmentPlanner',
         );
       });
   },
@@ -92,7 +92,7 @@ departmentplanner.post(
             req,
             res,
             { insertId: result[0] }, // Assuming auto-incremented ID
-            'Departmentplanner created successfully.',
+            'DepartmentPlanner created successfully.',
           );
         }
       })

--- a/src/routes/program.ts
+++ b/src/routes/program.ts
@@ -122,11 +122,11 @@ program.get(
       .select('Program.id')
       .join('Department', 'Department.id', 'Program.departmentId')
       .join(
-        'Departmentplanner',
-        'Departmentplanner.departmentId',
+        'DepartmentPlanner',
+        'DepartmentPlanner.departmentId',
         'Department.id',
       )
-      .join('User', 'User.id', 'Departmentplanner.userId')
+      .join('User', 'User.id', 'DepartmentPlanner.userId')
       .where('User.id', req.params.userId)
       .then((data) => {
         successHandler(

--- a/src/validationHandler/index.ts
+++ b/src/validationHandler/index.ts
@@ -133,6 +133,18 @@ export const createTimeValidatorChain = (
     .bail(),
 ];
 
+export const createTimeLengthValidatorChainHoursAndMinutes = (
+  fieldName: string,
+): ValidationChain[] => [
+  check(`${fieldName}`)
+    .matches(/^([0-2][0-9]):([0-5][0-9])$/)
+    .withMessage('Accepted format: 00:00, from 00:00 to 29:59')
+    .bail()
+    .notEmpty()
+    .withMessage('Cannot be empty')
+    .bail(),
+];
+
 export const createMultiTimeValidatorChain = (
   fieldName: string,
 ): ValidationChain[] => [


### PR DESCRIPTION
In some MariaDB databases / computers / environments the table and column names in SQL _ARE_ case sensitive. So let's always follow how they are written in the CREATE TABLE statements. That is e.g. DepartmentPlanner and not e.g. Departmentplanner nor departmentplanner.   

Hard to notice error when works for some and not for all. 