### PR TITLE
Trim input when validating name and description

### DIFF
--- a/src/validationHandler/index.ts
+++ b/src/validationHandler/index.ts
@@ -54,6 +54,7 @@ export const createNameValidatorChain = (
     .matches(/^[A-Za-zäöåÄÖÅ0-9\(\)\s\/,-]*$/)
     .withMessage(`${fieldName} must contain only letters, numbers and -`)
     .bail()
+    .trim()
     .notEmpty()
     .withMessage(`${fieldName} cannot be empty`)
     .bail(),
@@ -69,6 +70,7 @@ export const createDescriptionValidatorChain = (
     .matches(/^[A-Za-zäöåÄÖÅ0-9\(\)\s\/,.:-]*$/)
     .withMessage(`${fieldName} must contain only letters, numbers and -`)
     .bail()
+    .trim()
     .notEmpty()
     .withMessage(`${fieldName} cannot be empty`)
     .bail(),


### PR DESCRIPTION
Trims input removing leading and trailing whitespaces before checking if input is empty. This way blank names and descriptions that only contain whitespaces don't end up in the database.

See [this](https://express-validator.github.io/docs/guides/validation-chain#chaining-order) for reference.