### PR TITLE
Added items-per-page test data setting 

### DIFF
--- a/Database/SQL_Scripts/000__CreateALLdb.sql
+++ b/Database/SQL_Scripts/000__CreateALLdb.sql
@@ -1,4 +1,4 @@
-USE casedb; /* UPDATED 2024-01-24 */
+USE casedb; /* UPDATED 2024-02-26 */
 
 DROP TABLE IF EXISTS log_event;
 DROP TABLE IF EXISTS log_list;
@@ -854,7 +854,8 @@ DELIMITER ;
 /* --- Insert: GlobalSettings --- */
 INSERT INTO GlobalSetting(name, description, numberValue, textValue) VALUES
     ('X', 'Korkea prioriteettiarvo', 800, NULL),
-    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL);
+    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL),
+    ("items-per-page", "The number of items to display per page in lists. Default is 15.", 15, NULL);
 
 /* --- Insert: Department --- */
 INSERT INTO Department(name, description) VALUES

--- a/Database/SQL_Scripts/02__insert_test_data.sql
+++ b/Database/SQL_Scripts/02__insert_test_data.sql
@@ -1,10 +1,11 @@
-USE casedb; /* UPDATED 2024-01-24 */
+USE casedb; /* UPDATED 2024-02-26 */
 
 /* INSERTS */
 /* --- Insert: GlobalSettings --- */
 INSERT INTO GlobalSetting(name, description, numberValue, textValue) VALUES
     ('X', 'Korkea prioriteettiarvo', 800, NULL),
-    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL);
+    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL),
+    ("items-per-page", "The number of items to display per page in lists. Default is 15.", 15, NULL);
 
 /* --- Insert: Department --- */
 INSERT INTO Department(name, description) VALUES

--- a/Database/SQL_Scripts/06__drop_tables_create_tables_insert_test_data.sql
+++ b/Database/SQL_Scripts/06__drop_tables_create_tables_insert_test_data.sql
@@ -1,4 +1,4 @@
-USE casedb; /* UPDATED 2024-01-24 */
+USE casedb; /* UPDATED 2024-02-26 */
 
 DROP TABLE IF EXISTS log_event;
 DROP TABLE IF EXISTS log_list;
@@ -365,7 +365,8 @@ CREATE TABLE IF NOT EXISTS log_event (
 /* --- Insert: GlobalSettings --- */
 INSERT INTO GlobalSetting(name, description, numberValue, textValue) VALUES
     ('X', 'Korkea prioriteettiarvo', 800, NULL),
-    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL);
+    ("allocation-debug", "Onko allokoinnin logitus päällä. numberValue : 0 = OFF, 1 = ON", 1, NULL),
+    ("items-per-page", "The number of items to display per page in lists. Default is 15.", 15, NULL);
 
 /* --- Insert: Department --- */
 INSERT INTO Department(name, description) VALUES

--- a/request/GlobalSetting.rest
+++ b/request/GlobalSetting.rest
@@ -12,7 +12,7 @@ Authorization: Basic {{token}}
 
 ### Initial setup: Set the nextId after Testdata Reset
 ### It should come after the last id in test data
-@nextId=3
+@nextId=4
 
 
 ### 2. Get one by known id (use GlobalSetting id that is known to exist)


### PR DESCRIPTION
Added new test data setting to GlobalSetting database table to be able to change the number of items per page in frontend.

By the way, should the descriptions of other settings be changed to English, or do we leave them as they are?