### PR TITLE
Removed a runaway comma from code

### DIFF
--- a/src/services/allocation.ts
+++ b/src/services/allocation.ts
@@ -243,7 +243,7 @@ const getSpacesForSubject = async (subjectId: number): Promise<string> => {
       's.area',
       db_knex.raw(`getMissingItemAmount(${subjectId}, s.id) as missingItems`),
       db_knex.raw(
-        `IF(s.area >= (SELECT area FROM Subject WHERE id = ${subjectId}), TRUE, FALSE) AS areaOk,`,
+        `IF(s.area >= (SELECT area FROM Subject WHERE id = ${subjectId}), TRUE, FALSE) AS areaOk`,
       ),
       's.personLimit',
       db_knex.raw(


### PR DESCRIPTION
one alias had a comma connected to the name that caused the crash