### PR TITLE
getMissingEquipmentForRoom was missing as and gave an error

### DIFF
--- a/src/services/allocation.ts
+++ b/src/services/allocation.ts
@@ -281,7 +281,7 @@ const getMissingEquipmentForRoom = async (
 ): Promise<string> => {
   return db_knex
     .select('e.id', 'e.name')
-    .from('SubjectEquipment sub_eq')
+    .from('SubjectEquipment as sub_eq')
     .join('Equipment as e', 'sub_eq.equipmentId', 'e.id')
     .where('subjectId', subjectId)
     .except(


### PR DESCRIPTION
Noticed that browser console was giving an error when opening the unallocated lesson. Reason was a missing as in getMissingEquipmentForRoom.