### PR TITLE
Fixed typos in allocation db queries that caused errors

### DIFF
--- a/src/routes/spaceType.ts
+++ b/src/routes/spaceType.ts
@@ -113,7 +113,7 @@ spaceType.get(
   },
 );
 
-// adding single building
+// adding single spacetype
 spaceType.post(
   '/',
   validateSpaceTypePost,

--- a/src/services/allocation.ts
+++ b/src/services/allocation.ts
@@ -132,7 +132,7 @@ const getAllocatedRoomsBySubject = (
     )
     .from('AllocSpace as aspace')
     .leftJoin('Space as s', 'aspace.spaceId', 's.id')
-    .leftJoin('Subject sub', 'aspace.subjectId', 'sub.id')
+    .leftJoin('Subject as sub', 'aspace.subjectId', 'sub.id')
     .where('aspace.subjectId', subjectId)
     .andWhere('aspace.allocRoundId', allocRoundId)
     .groupBy('s.id');
@@ -224,7 +224,7 @@ const getUnAllocableSubjects = async (
     )
     .from('AllocSubject as all_sub')
     .join('Subject as s', 'all_sub.subjectId', 's.id')
-    .join('Spacetype as st', 's.spaceTypeId', 'st.id')
+    .join('SpaceType as st', 's.spaceTypeId', 'st.id')
     .where('cantAllocate', '1')
     .andWhere('s.allocRoundId', allocRoundId)
     .then((data) => {


### PR DESCRIPTION
I was completely unable to use the failed allocation feature in frontend because of one typo in database query code. I fixed that and also another typo. I don't know if anyone else had this problem? I have case sensitivity enabled by default in my local mariadb that I run with Docker.