### PR TITLE
Fixed the 24h bug in calculation

### DIFF
--- a/src/routes/allocation.ts
+++ b/src/routes/allocation.ts
@@ -193,7 +193,7 @@ allocation.get(
   },
 );
 
-/* Get all allocated rooms by RoomId, allocRound */
+/* Get all allocated subjects by RoomId, allocRound */
 allocation.get(
   '/:id/subjects/:roomId',
   [authenticator, admin, planner, statist, roleChecker, validate],

--- a/src/services/allocation.ts
+++ b/src/services/allocation.ts
@@ -177,7 +177,7 @@ const getAllocatedSubjectsByRoom = async (
     .select(
       'su.id',
       'su.name',
-      // EXTRACT(HOUR from ...) returns value from 0 to 23 in certain MariaDB versions.
+      // EXTRACT(HOUR FROM ...) returns hours from 0 to 23 in certain MariaDB versions.
       // Use HOUR instead to get more than 24 hours. https://mariadb.com/kb/en/extract/
       db_knex.raw(
         'TRUNCATE((HOUR(allocSp.totalTime) + (EXTRACT(MINUTE FROM allocSp.totalTime) / 60)), 2) as totalTime',

--- a/src/services/allocation.ts
+++ b/src/services/allocation.ts
@@ -177,9 +177,10 @@ const getAllocatedSubjectsByRoom = async (
     .select(
       'su.id',
       'su.name',
-      //'allocSp.totalTime'
+      // EXTRACT(HOUR from ...) returns value from 0 to 23 in certain MariaDB versions.
+      // Use HOUR instead to get more than 24 hours. https://mariadb.com/kb/en/extract/
       db_knex.raw(
-        'TRUNCATE((EXTRACT(hour from allocSp.totalTime) + (extract(minute from allocSp.totalTime)/60)), 2) as totalTime',
+        'TRUNCATE((HOUR(allocSp.totalTime) + (EXTRACT(MINUTE FROM allocSp.totalTime) / 60)), 2) as totalTime',
       ),
     )
     .from('AllocSpace as allocSp')


### PR DESCRIPTION
Finally found and fixed the bug that caused a lesson's calculated hours to never exceed 24 hours in Room Results. I tested this quite a lot. Let me know if the bug still appears.