### PR TITLE
SQL script: corect the typo from No ACTION to NO action 

### DIFF
--- a/Database/SQL_Scripts/01__create_tables.sql
+++ b/Database/SQL_Scripts/01__create_tables.sql
@@ -247,7 +247,7 @@ CREATE TABLE IF NOT EXISTS AllocSpace (
 
     CONSTRAINT `FK_AllocSpace_Space` FOREIGN KEY (spaceId)
         REFERENCES Space(id)
-        ON DELETE No ACTION
+        ON DELETE NO ACTION
         ON UPDATE CASCADE
 
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -269,7 +269,7 @@ CREATE TABLE IF NOT EXISTS AllocSubjectSuitableSpace (
     CONSTRAINT `FK_AllocSubjectSpace_Space`
         FOREIGN KEY (spaceId)
         REFERENCES Space(id)
-        ON DELETE No ACTION
+        ON DELETE NO ACTION
         ON UPDATE CASCADE
 
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
…SQL script: corect the typo from No ACTION to NO action for allocspace and allocsuitablespace tables.