### PR TITLE
Fixed the hours to show the actual time instead of removing every full 24 hours

### DIFF
--- a/src/routes/allocation.ts
+++ b/src/routes/allocation.ts
@@ -324,7 +324,7 @@ allocation.get(
         's.name as lesson',
         'sp.name as room',
         db_knex.raw(
-          'TRUNCATE((EXTRACT(hour from a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
+          'TRUNCATE((HOUR(a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
         ),
       )
       .from('AllocSpace as a')
@@ -395,7 +395,7 @@ allocation.get(
         's.name as lesson',
         'sp.name as room',
         db_knex.raw(
-          'TRUNCATE((EXTRACT(hour from a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
+          'TRUNCATE((HOUR(a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
         ),
       )
       .from('DepartmentPlanner as dp')
@@ -471,7 +471,7 @@ allocation.get(
         's.name as lesson',
         'sp.name as room',
         db_knex.raw(
-          'TRUNCATE((EXTRACT(hour from a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
+          'TRUNCATE((HOUR(a.totalTime) + (extract(minute from a.totalTime)/60)), 2) as hours',
         ),
       )
       .from('AllocSpace as a')


### PR DESCRIPTION
the Excel reports still had the EXTRACT(HOUR from a.totalTime) instead of  HOUR(a.totalTime)