### PR TITLE
Fixed some database case sensitivity errors

### DIFF
--- a/src/routes/equipment.ts
+++ b/src/routes/equipment.ts
@@ -208,7 +208,7 @@ equipment.get(
     const equipmentId = req.params.id;
     db_knex('Equipment')
       .join('SubjectEquipment', 'Equipment.id', 'SubjectEquipment.equipmentId')
-      .join('Subject', 'Subjectequipment.subjectId', 'Subject.id')
+      .join('Subject', 'SubjectEquipment.subjectId', 'Subject.id')
       .select('Subject.name')
       .where('equipmentId', equipmentId)
       .limit(5)

--- a/src/routes/space.ts
+++ b/src/routes/space.ts
@@ -398,7 +398,7 @@ space.get(
   [authenticator, admin, planner, statist, roleChecker, validate],
   (req: Request, res: Response) => {
     const spaceId = req.params.id;
-    db_knex('Allocspace')
+    db_knex('AllocSpace')
       .count('allocRoundId')
       .where('spaceId', spaceId)
       .then((allocRoundId) => {
@@ -426,14 +426,14 @@ space.get(
   [authenticator, admin, planner, statist, roleChecker, validate],
   (req: Request, res: Response) => {
     const spaceId = req.params.id;
-    db_knex('Allocspace')
+    db_knex('AllocSpace')
       .join(
         'AllocSubject',
-        'Allocspace.allocRoundId',
+        'AllocSpace.allocRoundId',
         'AllocSubject.allocRoundId',
       )
-      .join('Allocround', 'Allocspace.allocRoundId', 'Allocround.id')
-      .select('Allocround.name')
+      .join('AllocRound', 'AllocSpace.allocRoundId', 'AllocRound.id')
+      .select('AllocRound.name')
       .where('spaceId', spaceId)
       .limit(5)
       .then((allocRoundNames) => {


### PR DESCRIPTION
If running MariaDB on Linux then it has case sensitivity enabled by default. The deployed backend gave ER_NO_SUCH_TABLE errors so I fixed the case sensitivity problems.