### PR TITLE
Deployment scripts now reset database

### DIFF
--- a/Deployment/CSC_VM_docker_deployment.md
+++ b/Deployment/CSC_VM_docker_deployment.md
@@ -253,7 +253,7 @@ To deploy only the frontend changes:
 bash ~/siba/Siba_be/Deployment/scripts/deploy_frontend.sh
 ```
 
-The above scripts pull the latest changes from the git repositories, stop and remove running containers, and then rebuild the new images and start containers.
+The above scripts pull the latest changes from the git repositories, stop and remove running containers, and then rebuild the new images and start containers. New database changes are also applied by resetting the database. 
 
 ## Removing Docker volumes
 

--- a/Deployment/scripts/deploy_backend.sh
+++ b/Deployment/scripts/deploy_backend.sh
@@ -6,4 +6,5 @@ git pull
 
 sudo systemctl start docker
 sudo docker compose -f ~/siba/Siba_be/docker-compose-dbbe-deploy.yaml down
+sudo docker volume rm siba_be_mariadb_data
 sudo docker compose -f ~/siba/Siba_be/docker-compose-dbbe-deploy.yaml up -d --build

--- a/Deployment/scripts/deploy_whole_app.sh
+++ b/Deployment/scripts/deploy_whole_app.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Get the latest code changes from git repositories
+# Get the latest code changes from the git repositories
 cd ~/siba/siba-fe
 git switch main
 git pull
@@ -8,12 +8,15 @@ cd ~/siba/Siba_be
 git switch main
 git pull
 
-# Start the Docker daemon if it's not running.
+# Start the Docker daemon if it's not running
 sudo systemctl start docker
 
 # Stop and remove current containers
 sudo docker compose -f ~/siba/Siba_be/docker-compose-dbbe-deploy.yaml down
 sudo docker compose -f ~/siba/siba-fe/docker-compose-fe-nginx.yaml down
+
+# Apply new database changes by resetting the database
+sudo docker volume rm siba_be_mariadb_data
 
 # Rebuild the new images and start containers
 sudo docker compose -f ~/siba/Siba_be/docker-compose-dbbe-deploy.yaml up -d --build


### PR DESCRIPTION
The CSC cloud deployment scripts now reset the database by removing the Docker volume that the MariaDB container creates before starting a new database container. This way new database changes (new test data, column changes, etc.) can be applied automatically without having to manually remove the Docker volume.

Of course this will reset all the data in the live version and is not suitable for a "real" production environment, but it's pretty nice for a live testing environment.